### PR TITLE
Apply minimalistic Apple-style visuals

### DIFF
--- a/src/main/frontend/src/agents-panel/agents-panel.component.css
+++ b/src/main/frontend/src/agents-panel/agents-panel.component.css
@@ -7,7 +7,9 @@
   top: 168px;
   right: 16px;
   z-index: 1000;
-  background-color: var(--mat-sys-primary-container);
+  background-color: #ffffff;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
 }
 
 .sidenav-container {
@@ -26,7 +28,7 @@
 /* Enable pointer events on the sidenav itself */
 mat-sidenav {
   pointer-events: auto;
-  width: 300px;
+  width: min(300px, 90vw);
   padding: 16px;
   box-shadow: -3px 0 5px rgba(0, 0, 0, 0.1);
 }

--- a/src/main/frontend/src/app/app.component.css
+++ b/src/main/frontend/src/app/app.component.css
@@ -6,6 +6,9 @@ mat-toolbar {
   right: 0;
   z-index: 2;
   height: 64px;
+  background: rgba(255, 255, 255, 0.8);
+  backdrop-filter: blur(20px);
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.1);
 }
 
 /* Main content wrapper */

--- a/src/main/frontend/src/chat-panel/chat-panel.component.css
+++ b/src/main/frontend/src/chat-panel/chat-panel.component.css
@@ -7,7 +7,9 @@
   top: 72px; /* Positioned below the memory panel button */
   right: 16px;
   z-index: 1000;
-  background-color: var(--mat-sys-primary-container);
+  background-color: #ffffff;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
 }
 
 .sidenav-container {
@@ -26,7 +28,7 @@
 /* Enable pointer events on the sidenav itself */
 mat-sidenav {
   pointer-events: auto;
-  width: 300px;
+  width: min(300px, 90vw);
   padding: 16px;
   box-shadow: -3px 0 5px rgba(0, 0, 0, 0.1);
 }

--- a/src/main/frontend/src/chatbox/chatbox.component.css
+++ b/src/main/frontend/src/chatbox/chatbox.component.css
@@ -5,8 +5,9 @@
   left: 0;
   right: 0;
   top: 64px; /* Same as toolbar height */
-  padding: 15px;
-  width: 90%;
+  padding: 20px;
+  width: 100%;
+  max-width: 900px;
   margin: 0 auto;
   display: flex;
   flex-direction: column;
@@ -25,6 +26,7 @@
   margin-bottom: 10px;
   position: relative;
   word-wrap: break-word;
+  border-radius: 12px;
 }
 
 .chat-message.user {
@@ -43,6 +45,8 @@
 
 .chatbox-footer {
   margin-bottom: 15px;
+  padding-top: 10px;
+  border-top: 1px solid #e0e0e0;
 }
 
 .chatbox-footer input {
@@ -84,8 +88,19 @@
   transition: opacity 0.2s ease-in-out;
 }
 
+@media (max-width: 600px) {
+  .chatbox {
+    padding: 16px;
+  }
+
+  .chat-message {
+    max-width: 85%;
+  }
+}
+
 button {
   transition: opacity 0.2s ease-in-out, transform 0.1s ease-in-out;
+  border-radius: 8px;
 }
 
 button:active:not(:disabled) {

--- a/src/main/frontend/src/document-panel/document-panel.component.css
+++ b/src/main/frontend/src/document-panel/document-panel.component.css
@@ -7,7 +7,9 @@
   top: 120px;
   right: 16px;
   z-index: 1000;
-  background-color: var(--mat-sys-primary-container);
+  background-color: #ffffff;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
 }
 
 .sidenav-container {
@@ -26,7 +28,7 @@
 /* Enable pointer events on the sidenav itself */
 mat-sidenav {
   pointer-events: auto;
-  width: 350px;
+  width: min(350px, 90vw);
   padding: 16px;
   box-shadow: -3px 0 5px rgba(0, 0, 0, 0.1);
 }

--- a/src/main/frontend/src/memory-panel/memory-panel.component.css
+++ b/src/main/frontend/src/memory-panel/memory-panel.component.css
@@ -7,7 +7,9 @@
   top: 216px;
   right: 16px;
   z-index: 1000;
-  background-color: var(--mat-sys-primary-container);
+  background-color: #ffffff;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
 }
 
 .sidenav-container {
@@ -26,7 +28,7 @@
 /* Enable pointer events on the sidenav itself */
 mat-sidenav {
   pointer-events: auto;
-  width: 300px;
+  width: min(300px, 90vw);
   padding: 16px;
   box-shadow: -3px 0 5px rgba(0, 0, 0, 0.1);
 }

--- a/src/main/frontend/src/styles.css
+++ b/src/main/frontend/src/styles.css
@@ -1,7 +1,18 @@
 /* You can add global styles to this file, and also import other style files */
 
 html, body { height: 100%; }
-body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    'Helvetica Neue', sans-serif;
+  background-color: #f5f5f7;
+  color: #1d1d1f;
+  box-sizing: border-box;
+}
+
+*, *::before, *::after {
+  box-sizing: inherit;
+}
 
 /* Material Dialog overrides to prevent horizontal scrolling */
 .mat-mdc-dialog-container {
@@ -25,4 +36,15 @@ body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
 
 .prompt-selection-dialog-container .mat-mdc-dialog-container {
   overflow-x: hidden !important;
+}
+
+mat-card {
+  border-radius: 12px;
+  box-shadow: none;
+  border: 1px solid #e0e0e0;
+}
+
+button.mat-icon-button {
+  background: transparent;
+  border-radius: 8px;
 }

--- a/src/main/frontend/src/tools-modal/tools-modal.component.css
+++ b/src/main/frontend/src/tools-modal/tools-modal.component.css
@@ -58,6 +58,7 @@
   margin-right: 0; /* Ensure no right margin causing overflow */
   word-wrap: break-word; /* Handle long content */
   overflow-wrap: break-word; /* Modern property for word wrapping */
+  border-radius: 8px;
 }
 
 .tool-name {


### PR DESCRIPTION
## Summary
- tweak global style to use Apple-like fonts and colors
- give toolbar translucent look
- refine chatbox layout and button styles
- round edges for tool cards and panels
- add responsive widths for side panels and chat messages

## Testing
- `mvn -q test` *(fails: command not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875e9e90b908327858129be1c3ec61a